### PR TITLE
Integration of MPT into Page Table Walker

### DIFF
--- a/core/cache_subsystem/wt_dcache.sv
+++ b/core/cache_subsystem/wt_dcache.sv
@@ -259,7 +259,7 @@ module wt_dcache
   assign rd_prio[0] = 1'b1; // Assign higher priority to PTW
   assign rd_prio[1] = 1'b1; // Assign higher priority to Load Unit
   assign rd_prio[3] = 1'b0; // Assign lower priority to MPTW of Store Unit 
-  assign rd_prio[4] = 1'b1; // Assign higher priority to MPTW of IF Unit
+  assign rd_prio[4] = 1'b0; // Assign lower priority to MPTW of IF Unit
 
   ///////////////////////////////////////////////////////
   // store unit controller

--- a/core/cache_subsystem/wt_dcache.sv
+++ b/core/cache_subsystem/wt_dcache.sv
@@ -185,18 +185,17 @@ module wt_dcache
   );
 
   ///////////////////////////////////////////////////////
-  // read controllers (LD unit and PTW/MMU)
+  // read controllers (LD unit, PTW/MMU, MPTW of Store Unit and MPTW of IF Unit)
   ///////////////////////////////////////////////////////
 
   // 0 is used by MMU or implicit read by zcmt 
   // 1 by READ access requests 
   // 2 by accelerator
-  // 3 by READ acess requests from MPT used by store unit
-  // 4 by READ acess requests from MPT used by IF unit
+  // 3 by READ acess requests from MPTW used by Store Unit
+  // 4 by READ acess requests from MPTW used by IF Unit
   for (genvar k = 0; k < NumPorts - 1; k++) begin : gen_rd_ports
     // set these to high prio ports
     if ((k == 0 && (CVA6Cfg.MmuPresent || CVA6Cfg.RVZCMT )) || (k == 1) || (k == 2 && CVA6Cfg.EnableAccelerator) || (k==3) || (k==4)) begin
-      assign rd_prio[k] = 1'b1;
       wt_dcache_ctrl #(
           .CVA6Cfg(CVA6Cfg),
           .DCACHE_CL_IDX_WIDTH(DCACHE_CL_IDX_WIDTH),
@@ -256,6 +255,11 @@ module wt_dcache
       assign rd_tag_only[k] = 1'b0;
     end
   end
+
+  assign rd_prio[0] = 1'b1; // Assign higher priority to PTW
+  assign rd_prio[1] = 1'b1; // Assign higher priority to Load Unit
+  assign rd_prio[3] = 1'b0; // Assign lower priority to MPTW of Store Unit 
+  assign rd_prio[4] = 1'b1; // Assign higher priority to MPTW of IF Unit
 
   ///////////////////////////////////////////////////////
   // store unit controller

--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -98,6 +98,11 @@ module cva6_mmu
     input dcache_req_o_t req_port_i,
     output dcache_req_i_t req_port_o,
 
+    // MPT
+    input logic mptw_allow_i,
+    input logic mptw_valid_i,
+    output logic mptw_enable_o,
+
     // PMP
 
     input riscv::pmpcfg_t [avoid_neg(CVA6Cfg.NrPMPEntries-1):0]                   pmpcfg_i,
@@ -344,6 +349,12 @@ module cva6_mmu
 
       // Performance counters
       .shared_tlb_miss_o(shared_tlb_miss),  //open for now
+
+      // MPT
+      .priv_lvl_i (priv_lvl_i),
+      .mptw_allow_i (mptw_allow_i),
+      .mptw_valid_i (mptw_valid_i),
+      .mptw_enable_o (mptw_enable_o),
 
       // PMP
       .pmpcfg_i   (pmpcfg_i),

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -378,7 +378,7 @@ module cva6_ptw
 
           is_instr_ptw_n    = itlb_req_i;
           vaddr_n           = shared_tlb_vaddr_i;
-          state_d           = WAIT_MPT;
+          state_d           = (!CVA6Cfg.SMMPT) ? WAIT_GRANT: WAIT_MPT;
           shared_tlb_miss_o = 1'b1;
 
           if (itlb_req_i) begin
@@ -447,7 +447,7 @@ module cva6_ptw
                 case (ptw_stage_q)
                   S_STAGE: begin
                     if ((is_instr_ptw_q && enable_g_translation_i) || (!is_instr_ptw_q && en_ld_st_g_translation_i)) begin
-                      state_d = WAIT_MPT;
+                      state_d = (!CVA6Cfg.SMMPT) ? WAIT_GRANT: WAIT_MPT;
                       ptw_stage_d = G_FINAL_STAGE;
                       if (CVA6Cfg.RVH) gpte_d = pte;
                       ptw_lvl_n[HYP_EXT] = ptw_lvl_q[0];
@@ -461,7 +461,7 @@ module cva6_ptw
                     end
                   end
                   G_INTERMED_STAGE: begin
-                    state_d = WAIT_MPT;
+                    state_d = (!CVA6Cfg.SMMPT) ? WAIT_GRANT: WAIT_MPT;
                     ptw_stage_d = S_STAGE;
                     ptw_lvl_n[0] = ptw_lvl_q[HYP_EXT];
                     pptr = {pte.ppn[CVA6Cfg.GPPNW-1:0], gptw_pptr_q[11:0]};
@@ -539,7 +539,7 @@ module cva6_ptw
 
               end else begin
                 ptw_lvl_n[0] = ptw_lvl_q[0] + 1'b1;
-                state_d = WAIT_MPT;
+                state_d = (!CVA6Cfg.SMMPT) ? WAIT_GRANT: WAIT_MPT;
 
                 if (CVA6Cfg.RVH) begin
                   case (ptw_stage_q)

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -378,7 +378,6 @@ module cva6_ptw
 
           is_instr_ptw_n    = itlb_req_i;
           vaddr_n           = shared_tlb_vaddr_i;
-          //state_d           = WAIT_GRANT;
           state_d           = WAIT_MPT;
           shared_tlb_miss_o = 1'b1;
 
@@ -448,7 +447,6 @@ module cva6_ptw
                 case (ptw_stage_q)
                   S_STAGE: begin
                     if ((is_instr_ptw_q && enable_g_translation_i) || (!is_instr_ptw_q && en_ld_st_g_translation_i)) begin
-                      //state_d = WAIT_GRANT;
                       state_d = WAIT_MPT;
                       ptw_stage_d = G_FINAL_STAGE;
                       if (CVA6Cfg.RVH) gpte_d = pte;
@@ -463,7 +461,6 @@ module cva6_ptw
                     end
                   end
                   G_INTERMED_STAGE: begin
-                    // state_d = WAIT_GRANT;
                     state_d = WAIT_MPT;
                     ptw_stage_d = S_STAGE;
                     ptw_lvl_n[0] = ptw_lvl_q[HYP_EXT];
@@ -542,7 +539,6 @@ module cva6_ptw
 
               end else begin
                 ptw_lvl_n[0] = ptw_lvl_q[0] + 1'b1;
-                //state_d = WAIT_GRANT;
                 state_d = WAIT_MPT;
 
                 if (CVA6Cfg.RVH) begin

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -621,14 +621,14 @@ module load_store_unit
   end
 
   // Selects the source of D$ port 0 requests: either the MPTW of the PTW or PTW
-  // depending on whether the MPTW is currently handling a request.
+  // depending on whether the MPTW is currently handling a request
   always_comb begin : mux_mptw_ptw_req
     dcache_req_ports_o[0] = '{default: '0};
     mptw_ptw_dcache_req_i = '{default: '0};
     ptw_dcache_req_i     = '{default: '0};
 
-    if (mptw_load_en_int) begin
-      mptw_ptw_dcache_req_i = dcache_req_ports_i[1];
+    if (mptw_ptw_en_int) begin
+      mptw_ptw_dcache_req_i = dcache_req_ports_i[0];
       dcache_req_ports_o[0] = mptw_ptw_dcache_req_o;
     end else begin  
       ptw_dcache_req_i = dcache_req_ports_i[0];
@@ -746,8 +746,8 @@ module load_store_unit
     .allow_ifu_o               (mptw_if_allow_int),
     // MPTW of the PTW
     .ptw_ptw_enable_i          (mptw_ptw_en_int),
-    .ptw_spa_i                 ({mptw_ptw_dcache_req_o.address_index, mptw_ptw_dcache_req_o.address_tag}),
-    .addr_ptw_valid_i          (mptw_ptw_dcache_req_o.tag_valid),
+    .ptw_spa_i                 ({ptw_dcache_req_o.address_tag, ptw_dcache_req_o.address_index}),
+    .addr_ptw_valid_i          (mptw_ptw_en_int),
     .mmpt_ptw_reg_i            (mmpt_i),
     .ptw_access_page_fault_o   (ptw_access_page_fault_int),
     .ptw_format_error_o        (ptw_format_error_int),

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -249,6 +249,10 @@ module load_store_unit
   // New dcache internal signals used by Load Unit, Store Unit, MPTW of the Load Unit and MPTW of the Store Unit
   dcache_req_o_t mptw_load_dcache_req_i;             
   dcache_req_i_t mptw_load_dcache_req_o;
+  dcache_req_o_t mptw_ptw_dcache_req_i;             
+  dcache_req_i_t mptw_ptw_dcache_req_o;
+  dcache_req_o_t ptw_dcache_req_i;             
+  dcache_req_i_t ptw_dcache_req_o;
   dcache_req_o_t load_dcache_req_i;             
   dcache_req_i_t load_dcache_req_o;
   // Internal signals used by MPTW of the Load Unit
@@ -263,6 +267,10 @@ module load_store_unit
   logic mptw_if_en_int, mptw_if_allow_int, mptw_if_valid_int, mptw_if_busy_int, if_access_page_fault_int;
   logic [2:0] if_format_error_int;
   logic [72:0] plb_entry_if_int;
+  // Internal signals used by MPTW of the IF Unit
+  logic mptw_ptw_en_int, mptw_ptw_allow_int, mptw_ptw_valid_int, mptw_ptw_busy_int, ptw_access_page_fault_int;
+  logic [2:0] ptw_format_error_int;
+  logic [72:0] plb_entry_ptw_int;
 
   // -------------------
   // MMU e.g.: TLBs/PTW
@@ -333,8 +341,12 @@ module load_store_unit
         .itlb_miss_o(itlb_miss_o),
         .dtlb_miss_o(dtlb_miss_o),
 
-        .req_port_i(dcache_req_ports_i[0]),
-        .req_port_o(dcache_req_ports_o[0]),
+        .req_port_i(ptw_dcache_req_i),
+        .req_port_o(ptw_dcache_req_o),
+
+        .mptw_allow_i (mptw_ptw_allow_int),
+        .mptw_valid_i (mptw_ptw_valid_int),
+        .mptw_enable_o (mptw_ptw_en_int),
 
         .pmpcfg_i,
         .pmpaddr_i
@@ -608,6 +620,22 @@ module load_store_unit
     end
   end
 
+  // Selects the source of D$ port 0 requests: either the MPTW of the PTW or PTW
+  // depending on whether the MPTW is currently handling a request.
+  always_comb begin : mux_mptw_ptw_req
+    dcache_req_ports_o[0] = '{default: '0};
+    mptw_ptw_dcache_req_i = '{default: '0};
+    ptw_dcache_req_i     = '{default: '0};
+
+    if (mptw_load_en_int) begin
+      mptw_ptw_dcache_req_i = dcache_req_ports_i[1];
+      dcache_req_ports_o[0] = mptw_ptw_dcache_req_o;
+    end else begin  
+      ptw_dcache_req_i = dcache_req_ports_i[0];
+      dcache_req_ports_o[0] = ptw_dcache_req_o;
+    end
+  end
+
   // virtual address causing the exception
   logic [CVA6Cfg.XLEN-1:0] fetch_vaddr_xlen;
   icache_areq_t icache_areq_o_int;
@@ -688,7 +716,7 @@ module load_store_unit
     // MPTW of the Store Unit
     .flush_i                   (flush_i),
     .ptw_store_enable_i        (mptw_store_en_int),
-    .addr_store_valid_i        (st_valid),
+    .addr_store_valid_i        (pmp_translation_valid),
     .mmpt_store_reg_i          (mmpt_i),
     .store_access_page_fault_o (store_access_page_fault_int),
     .store_format_error_o      (store_format_error_int),
@@ -698,7 +726,7 @@ module load_store_unit
     .allow_store_o             (mptw_store_allow_int),
     // MPTW of the Load Unit
     .ptw_load_enable_i         (mptw_load_en_int),
-    .addr_load_valid_i         (ld_valid),
+    .addr_load_valid_i         (pmp_translation_valid),
     .mmpt_load_reg_i           (mmpt_i),
     .load_access_page_fault_o  (load_access_page_fault_int),
     .load_format_error_o       (load_format_error_int),
@@ -716,13 +744,27 @@ module load_store_unit
     .ptw_ifu_valid_o           (mptw_if_valid_int),                  
     .plb_entry_ifu_o           (plb_entry_if_int),            
     .allow_ifu_o               (mptw_if_allow_int),
+    // MPTW of the PTW
+    .ptw_ptw_enable_i          (mptw_ptw_en_int),
+    .ptw_spa_i                 ({mptw_ptw_dcache_req_o.address_index, mptw_ptw_dcache_req_o.address_tag}),
+    .addr_ptw_valid_i          (mptw_ptw_dcache_req_o.tag_valid),
+    .mmpt_ptw_reg_i            (mmpt_i),
+    .ptw_access_page_fault_o   (ptw_access_page_fault_int),
+    .ptw_format_error_o        (ptw_format_error_int),
+    .ptw_ptw_busy_o            (mptw_ptw_busy_int),
+    .ptw_ptw_valid_o           (mptw_ptw_valid_int),
+    .plb_entry_ptw_o           (plb_entry_ptw_int),
+    .allow_ptw_o               (mptw_ptw_allow_int),
+
     // Dcache port
     .req_port_i_mptw_if         (dcache_req_ports_i[4]),
     .req_port_o_mptw_if         (dcache_req_ports_o[4]),
     .req_port_i_mptw_load       (mptw_load_dcache_req_i),
     .req_port_o_mptw_load       (mptw_load_dcache_req_o),
     .req_port_i_mptw_store      (dcache_req_ports_i[3]),
-    .req_port_o_mptw_store      (dcache_req_ports_o[3])
+    .req_port_o_mptw_store      (dcache_req_ports_o[3]),
+    .req_port_i_mptw_ptw        (mptw_ptw_dcache_req_i),
+    .req_port_o_mptw_ptw        (mptw_ptw_dcache_req_o)
   );
 
   // ----------------------------

--- a/verif/tests/custom/mptw_test/mptw_test.c
+++ b/verif/tests/custom/mptw_test/mptw_test.c
@@ -1,7 +1,7 @@
 /*
  Author: Valerio Di Domenico <valerio.didomenico@unina.it>
  Description:
-   This code is used to test MPTWs.
+   This code is used to test MPTWs of PTW, Load Unit, Store Unit and IF Unit.
 */
 
 
@@ -68,13 +68,13 @@ int main() {
 
     uint64_t *mpt_entry1 = (uint64_t *)0x81000000;
 
-/*
+/*  //******************* Test case 1 *********************************
     //******************* 1-walking level *****************************
     
     // Leaf-entry --> access allowed
-    *mpt_entry1 = 0x03FFFFFFFFFFFC03ULL;
+    *mpt_entry1 = 0x3FFFFFFFFFFFC03ULL;
 */
-/*
+/*  //******************* Test case 2 *********************************
     //******************* 2-walking levels *****************************
 
     // Non-leaf entry
@@ -83,7 +83,8 @@ int main() {
     uint64_t *mpt_entry2 = (uint64_t *)0x90000000;
     *mpt_entry2 = 0x3FFFFFFFFFFFC03ULL;
  */
-    //******************* 3-walking levels *****************************
+    //******************* Test case 3 *********************************
+    //******************* 4-walking levels *****************************
 
     // Non-leaf entry
     *mpt_entry1 = 0x0000000024000001ULL;
@@ -94,8 +95,8 @@ int main() {
     uint64_t *mpt_entry3 = (uint64_t *)0x90000200;
     *mpt_entry3 = 0x3FFFFFFFFFFFC03ULL;
 
-/*
-    //******************* 3-walking levels with error *******************
+/*  //******************* Test case 4 ********************************* 
+    //******************* 4-walking levels with error *******************
 
     // Non-leaf entry
     *mpt_entry1 = 0x0000000024000001ULL;

--- a/verif/tests/custom/mptw_test/mptw_test.c
+++ b/verif/tests/custom/mptw_test/mptw_test.c
@@ -114,7 +114,7 @@ int main() {
         : "r"(write_val)
         : "memory"
     );
-/*
+
     // Write satp register to enable virtual memory
     __asm__ volatile (
         "csrw satp, %0"
@@ -124,7 +124,7 @@ int main() {
 
     uint64_t *page_table_entry1 = (uint64_t *)0x80008010; // Address of the first page table entry
     *page_table_entry1 = 0b100000000000000000000011101111ULL; // Value of the first page table entry
-*/
+
     jump_to_s();  // jump to S-mode
     return 0;
 }

--- a/verif/tests/custom/mptw_test/mptw_test.c
+++ b/verif/tests/custom/mptw_test/mptw_test.c
@@ -4,25 +4,6 @@
    This code is used to test MPTWs of PTW, Load Unit, Store Unit and IF Unit.
 */
 
-
-//*************************************** DEFAULT *************************************** 
-/*
-#include <stdint.h>
-#include <stdio.h>
-
-int main(int argc, char* arg[]) {
-	
-	printf("%d: Hello World !", 0);
-	
-	int a = 0;
-	for (int i = 0; i < 5; i++)
-	{
-		a += i;
-	}
-	return 0;
-}
-*/
-
 //*************************************** MPT TESTS *************************************** */
 
 #include <stdint.h>

--- a/verif/tests/custom/mptw_test/mptw_test.c
+++ b/verif/tests/custom/mptw_test/mptw_test.c
@@ -82,7 +82,7 @@ int main() {
     // Leaf-entry --> access allowed  
     uint64_t *mpt_entry2 = (uint64_t *)0x90000000;
     *mpt_entry2 = 0x3FFFFFFFFFFFC03ULL;
-*/   
+ */
     //******************* 3-walking levels *****************************
 
     // Non-leaf entry
@@ -106,7 +106,7 @@ int main() {
     uint64_t *mpt_entry3 = (uint64_t *)0x90000200;
     *mpt_entry3 = 0x0000000000000003ULL;
 */
-/*
+
     // Enable MPT via MMPT register
     __asm__ volatile (
         "csrw 0x7C3, %0"
@@ -114,7 +114,7 @@ int main() {
         : "r"(write_val)
         : "memory"
     );
-*/
+/*
     // Write satp register to enable virtual memory
     __asm__ volatile (
         "csrw satp, %0"
@@ -123,8 +123,8 @@ int main() {
     ); // we have to shift the ppn by 12 bits because PTW computes "a" value as satp.ppn*PAGESIZE where PAGESIZE is 4096 (2^12)
 
     uint64_t *page_table_entry1 = (uint64_t *)0x80008010; // Address of the first page table entry
-    *page_table_entry1 = 0b100000000000000000000001001011ULL; // Value of the first page table entry
-
+    *page_table_entry1 = 0b100000000000000000000011101111ULL; // Value of the first page table entry
+*/
     jump_to_s();  // jump to S-mode
     return 0;
 }


### PR DESCRIPTION
This PR integrates the MPTW mechanism into the Page Table Walker.
It also adds support for exceptions raised by the Memory Protection Table, implemented in full analogy with the existing PMP exception handling.
To correctly manage MPTW requests from the PTW to the D$, the read port used by the PTW has been multiplexed between the MPTW and the PTW itself.



